### PR TITLE
Docker Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ COPY . .
 
 RUN cargo build --release
 
-FROM debian:slim
+FROM debian:buster-slim
 
-RUN apt-get update && apt-get install -y extra-runtime-dependencies && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libcurl4-openssl-dev libelf-dev libdw-dev binutils-dev && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/src/dartbot/target/release/dartbot /usr/local/bin/dartbot
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM rust:1.45.0 as builder
+
+WORKDIR /usr/src/dartbot
+
+COPY . .
+
+RUN cargo build --release
+
+FROM debian:slim
+
+RUN apt-get update && apt-get install -y extra-runtime-dependencies && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/src/dartbot/target/release/dartbot /usr/local/bin/dartbot
+
+CMD ["dartbot"]

--- a/README.md
+++ b/README.md
@@ -10,3 +10,13 @@ Ein Telegram-Bot der erfolgreiches Dartspiel mit 1 Woche Auszeit belohnt
 
 1. `export BOT_TOKEN=123456789:abcdefgh`
 2. `cargo run`
+
+oder 
+
+1. `docker build -t dartbot:latest .`
+2. `docker run -e BOT_TOKEN=123456789:abcdefgh dartbot:latest`
+
+oder (ohne Docker build)
+
+1. `docker run -e BOT_TOKEN=123456789:abcdefgh docker.registry.github.com/whentze/dartbot/dartbot:latest`
+


### PR DESCRIPTION
Diese Zuganfrage fügt Unterstützung für Docker hinzu. Einfach `docker build -t dartbot:latest .` im Repository ausführen und warten, bis die Binary kompiliert wurde und in einen entsprechend schlankeren Container ohne build toolchain geschnürt wurde.

Danach mit `docker run -e BOT_TOKEN=1234567890:abcdefg dartbot:latest` ausführen und Spaß haben (oder alternativ in entsprechende docker-compose Spezifikation übersetzten)!